### PR TITLE
fixed fin() function

### DIFF
--- a/dameware-poc.py
+++ b/dameware-poc.py
@@ -55,7 +55,7 @@ thread.start()
 time.sleep(10)
 
 def fin():
-  server.shutdown()
+  s.shutdown(socket.SHUT_RDWR)
 
 
 #source https://raw.githubusercontent.com/tenable/poc/master/Solarwinds/Dameware/dwrcs_dwDrvInst_rce.py


### PR DESCRIPTION
Was erroring out at the end when fin() was called, saying that server global variable not set, changed to s, then added argument for shutdown().